### PR TITLE
Implement home page with Sanity data integration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 // n https://www.youtube.com/watch?v=OcTPaUfay5I
-import { getProjects } from "@/sanity/sanity-utils";
+import { getHomePage } from "@/sanity/sanity-utils";
 import { PortableText } from "next-sanity";
 
 import PhotoGallery from "@/components/PhotoGallery/PhotoGallery";
@@ -7,21 +7,22 @@ import Section from "@/components/Section/Section";
 import Button from "@/components/Button/Button";
 import Link from "next/link";
 
+import { HomePage } from "@/types/HomePage";
+
 export default async function Home() {
-  const projects = await getProjects(); // projects fetched as Promise, type checked in sanity-utils.ts
-  // console.log("Fetched projects:", projects);  Debugging statement
+  const homePage = await getHomePage();
+  console.log("Fetched home page data:", homePage); // Debugging statement
 
   return (
     <>
-      <PhotoGallery />
       <Section title="Project Overview">
-        <p>Project overview text goes here...</p>
+        <PortableText value={homePage[0].projectOverview} />
       </Section>
       <Section title="Project Updates & Events">
-        <p>Project updates and events text goes here...</p>
+        <PortableText value={homePage[0].projectUpdates} />
       </Section>
       <Section title="Leave a Comment">
-        <p>If you have any comments, please leave them below:</p>
+        <PortableText value={homePage[0].leaveComment} />
         <Link href="/submit-comments">
           <Button>Leave a Comment</Button>
         </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,10 @@ export default async function Home() {
     <>
       {/* <PhotoGallery images={homePage.photoGallery} /> */}
 
+      <h1 className="text-4xl flex items-center w-full justify-center">
+        {homePage.title}
+      </h1>
+
       {homePage.sections.map((section, index) => (
         <Section
           key={index}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-// n https://www.youtube.com/watch?v=OcTPaUfay5I
 import { getHomePage } from "@/sanity/sanity-utils";
 import { PortableText } from "next-sanity";
 
@@ -10,23 +9,29 @@ import Link from "next/link";
 import { HomePage } from "@/types/HomePage";
 
 export default async function Home() {
-  const homePage = await getHomePage();
+  const homePage: HomePage = await getHomePage();
   console.log("Fetched home page data:", homePage); // Debugging statement
 
   return (
     <>
-      <Section title="Project Overview">
-        <PortableText value={homePage[0].projectOverview} />
-      </Section>
-      <Section title="Project Updates & Events">
-        <PortableText value={homePage[0].projectUpdates} />
-      </Section>
-      <Section title="Leave a Comment">
-        <PortableText value={homePage[0].leaveComment} />
-        <Link href="/submit-comments">
-          <Button>Leave a Comment</Button>
-        </Link>
-      </Section>
+      {/* <PhotoGallery images={homePage.photoGallery} /> */}
+
+      {homePage.sections.map((section, index) => (
+        <Section
+          key={index}
+          title={section.title}
+          imageIsOnRight={section.imageIsOnRight}
+          imageSrc={section.image.asset.url}
+          altText={section.altText}
+        >
+          <PortableText value={section.content} />
+          {section.buttonText && section.buttonLink && (
+            <Link href={section.buttonLink} className="inline-block mt-4">
+              <Button>{section.buttonText}</Button>
+            </Link>
+          )}
+        </Section>
+      ))}
     </>
   );
 }

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -5,7 +5,11 @@ interface ButtonProps {
 }
 
 const Button = ({ children }: ButtonProps) => {
-  return <button className="btn">{children}</button>;
+  return (
+    <button className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">
+      {children}
+    </button>
+  );
 };
 
 export default Button;

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer = () => {
   return (
-    <footer className="bg-gray-800 text-white p-4">
+    <footer className="bg-gray-800 text-white p-4 text-center">
       <p>Footer content goes here</p>
     </footer>
   );

--- a/components/Logo/Logo.tsx
+++ b/components/Logo/Logo.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Logo = () => {
   return (
-    <div className="logo">
+    <div className="text-xl font-bold">
       <h1>Site Logo</h1>
     </div>
   );

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -4,8 +4,8 @@ interface SectionProps {
   title: string;
   imageIsOnRight: boolean;
   children: ReactNode;
-  imageSrc: string; // Adding an image source prop
-  altText: string; // Accessibility improvement
+  imageSrc: string;
+  altText: string;
 }
 
 const Section = ({

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -7,8 +7,8 @@ interface SectionProps {
 
 const Section = ({ title, children }: SectionProps) => {
   return (
-    <section>
-      <h2>{title}</h2>
+    <section className="my-8 p-4 bg-gray-100 rounded-lg">
+      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
       <div>{children}</div>
     </section>
   );

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -2,14 +2,41 @@ import React, { ReactNode } from "react";
 
 interface SectionProps {
   title: string;
+  imageIsOnRight: boolean;
   children: ReactNode;
+  imageSrc: string; // Adding an image source prop
+  altText: string; // Accessibility improvement
 }
 
-const Section = ({ title, children }: SectionProps) => {
+const Section = ({
+  title,
+  children,
+  imageIsOnRight,
+  imageSrc,
+  altText,
+}: SectionProps) => {
   return (
-    <section className="my-8 p-4 bg-gray-100 rounded-lg">
-      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
-      <div>{children}</div>
+    <section className="my-8 p-8 bg-gray-100 rounded-lg">
+      <div
+        className={`flex flex-col md:flex-row items-center ${
+          imageIsOnRight ? "md:flex-row" : "md:flex-row-reverse"
+        }`}
+      >
+        {/* Content Section */}
+        <div className="w-full md:w-1/2 text-center md:text-left p-4">
+          <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+          <div>{children}</div>
+        </div>
+
+        {/* Image Section */}
+        <div className="w-full md:w-1/2 p-4 flex justify-center">
+          <img
+            src={imageSrc}
+            alt={altText}
+            className="w-full h-auto max-h-96 object-cover rounded-lg shadow-md"
+          />
+        </div>
+      </div>
     </section>
   );
 };

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -29,24 +29,36 @@ export async function getProjects(): Promise<Project[]> {
   }
 }
 
-export async function getHomePage(): Promise<HomePage[]> {
+export async function getHomePage(): Promise<HomePage> {
   try {
     const homePage = await client.fetch(
-      groq`*[_type == "homePage"]{
+      groq`*[_type == "homePage"][0]{
         _id,
         _createdAt,
         title,
-          photoGallery[]{
+        photoGallery[]{
           asset->{
             _id,
             url
           }
         },
-        projectOverview,
-        projectUpdates,
-        leaveComment
+        sections[]{
+          title,
+          content,
+          image{
+            asset->{
+              _id,
+              url
+            }
+          },
+          altText,
+          imageIsOnRight,
+          buttonText,
+          buttonLink
+        }
       }`
     );
+
     return homePage;
   } catch (error) {
     console.error("Failed to fetch homePage:", error);

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -3,9 +3,9 @@ import { Project } from "@/types/Project";
 import { HomePage } from "@/types/HomePage";
 
 const client = createClient({
-  projectId: "cktujo7h",
-  dataset: "production",
-  apiVersion: "2025-01-21",
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION,
   useCdn: true,
 });
 

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -1,14 +1,15 @@
 import { createClient, groq } from "next-sanity";
 import { Project } from "@/types/Project";
+import { HomePage } from "@/types/HomePage";
+
+const client = createClient({
+  projectId: "cktujo7h",
+  dataset: "production",
+  apiVersion: "2025-01-21",
+  useCdn: true,
+});
 
 export async function getProjects(): Promise<Project[]> {
-  const client = createClient({
-    projectId: "cktujo7h",
-    dataset: "production",
-    apiVersion: "2025-01-21",
-    useCdn: true,
-  });
-
   try {
     const projects = await client.fetch(
       groq`*[_type == "project"]{
@@ -25,5 +26,30 @@ export async function getProjects(): Promise<Project[]> {
   } catch (error) {
     console.error("Failed to fetch projects:", error);
     throw new Error("Failed to fetch projects");
+  }
+}
+
+export async function getHomePage(): Promise<HomePage[]> {
+  try {
+    const homePage = await client.fetch(
+      groq`*[_type == "homePage"]{
+        _id,
+        _createdAt,
+        title,
+          photoGallery[]{
+          asset->{
+            _id,
+            url
+          }
+        },
+        projectOverview,
+        projectUpdates,
+        leaveComment
+      }`
+    );
+    return homePage;
+  } catch (error) {
+    console.error("Failed to fetch homePage:", error);
+    throw new Error("Failed to fetch homePage");
   }
 }

--- a/sanity/schemas/home-page-schema.ts
+++ b/sanity/schemas/home-page-schema.ts
@@ -1,0 +1,39 @@
+const homePage = {
+  name: "homePage",
+  title: "Home Page",
+  type: "document",
+  fields: [
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule: any) => Rule.required().error("Title is required"),
+    },
+    {
+      name: "photoGallery",
+      title: "Photo Gallery",
+      type: "array",
+      of: [{ type: "image" }],
+    },
+    {
+      name: "projectOverview",
+      title: "Project Overview",
+      type: "array",
+      of: [{ type: "block" }],
+    },
+    {
+      name: "projectUpdates",
+      title: "Project Updates & Events",
+      type: "array",
+      of: [{ type: "block" }],
+    },
+    {
+      name: "leaveComment",
+      title: "Leave a Comment",
+      type: "array",
+      of: [{ type: "block" }],
+    },
+  ],
+};
+
+export default homePage;

--- a/sanity/schemas/home-page-schema.ts
+++ b/sanity/schemas/home-page-schema.ts
@@ -15,23 +15,70 @@ const homePage = {
       type: "array",
       of: [{ type: "image" }],
     },
+
     {
-      name: "projectOverview",
-      title: "Project Overview",
+      name: "sections",
+      title: "Sections",
       type: "array",
-      of: [{ type: "block" }],
-    },
-    {
-      name: "projectUpdates",
-      title: "Project Updates & Events",
-      type: "array",
-      of: [{ type: "block" }],
-    },
-    {
-      name: "leaveComment",
-      title: "Leave a Comment",
-      type: "array",
-      of: [{ type: "block" }],
+      of: [
+        {
+          type: "object",
+          name: "section",
+          title: "Section",
+          fields: [
+            {
+              name: "title",
+              title: "Title",
+              type: "string",
+              validation: (Rule: any) =>
+                Rule.required().error("Section title is required"),
+            },
+            {
+              name: "content",
+              title: "Content",
+              type: "array",
+              of: [{ type: "block" }],
+            },
+            {
+              name: "image",
+              title: "Image",
+              type: "image",
+              options: { hotspot: true },
+            },
+            {
+              name: "altText",
+              title: "Alt Text",
+              type: "string",
+              description: "Describe the image for accessibility.",
+              validation: (Rule: any) =>
+                Rule.required().error("Alt text is required"),
+            },
+            {
+              name: "imageIsOnRight",
+              title: "Image on Right",
+              type: "boolean",
+              description:
+                "If checked, the image will appear on the right side.",
+            },
+            {
+              name: "buttonText",
+              title: "Button Text",
+              type: "string",
+              description: "Text displayed on the button.",
+            },
+            {
+              name: "buttonLink",
+              title: "Button Link",
+              type: "url",
+              description: "URL the button will link to.",
+              validation: (Rule: any) =>
+                Rule.uri({
+                  scheme: ["http", "https", "mailto", "tel"],
+                }),
+            },
+          ],
+        },
+      ],
     },
   ],
 };

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import project from "./project-schema";
+import homePage from "./home-page-schema";
 
-const schemas = [project];
+const schemas = [project, homePage];
 
 export default schemas;

--- a/types/HomePage.ts
+++ b/types/HomePage.ts
@@ -1,0 +1,16 @@
+import { PortableTextBlock } from "next-sanity";
+
+export type HomePage = {
+  _id: string;
+  _createdAt: Date;
+  title: string;
+  photoGallery: {
+    asset: {
+      _id: string;
+      url: string;
+    };
+  }[];
+  projectOverview: PortableTextBlock[];
+  projectUpdates: PortableTextBlock[];
+  leaveComment: PortableTextBlock[];
+};

--- a/types/HomePage.ts
+++ b/types/HomePage.ts
@@ -13,4 +13,20 @@ export type HomePage = {
   projectOverview: PortableTextBlock[];
   projectUpdates: PortableTextBlock[];
   leaveComment: PortableTextBlock[];
+  sections: HomePageSection[];
+};
+
+export type HomePageSection = {
+  title: string;
+  content: PortableTextBlock[];
+  image: {
+    asset: {
+      _id: string;
+      url: string;
+    };
+  };
+  altText: string;
+  imageIsOnRight: boolean;
+  buttonText?: string;
+  buttonLink?: string;
 };


### PR DESCRIPTION
Set up the home page schema in Sanity, fetch home page data, and render it on the frontend with basic styling. Update components to accommodate new data structure and improve button and section layouts.