### PR TITLE
Disable CDN for fresh data on every request

### DIFF
--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -8,7 +8,7 @@ const client = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
   apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION,
-  useCdn: true,
+  useCdn: false,
 });
 
 export async function getProjects(): Promise<Project[]> {


### PR DESCRIPTION
Configure the client to fetch fresh data on each request by disabling the CDN.