### PR TITLE
Require image in home page schema and update navbar

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -7,9 +7,9 @@ import { Menu, X } from "lucide-react";
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/process", label: "Process" },
-  { href: "/document-library", label: "Document Library" },
-  { href: "/faq", label: "FAQ" },
   { href: "/get-involved", label: "Get Involved" },
+  { href: "/faq", label: "FAQ" },
+  { href: "/document-library", label: "Document Library" },
   { href: "/submit-comments", label: "Provide Feedback" },
 ];
 

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -112,6 +112,7 @@ export async function getProjectInfo(): Promise<ProjectInfo> {
           }
         },
         alt,
+        subheading,
         bulletPoints,
         detailedDescription
       }

--- a/sanity/schemas/homePage.ts
+++ b/sanity/schemas/homePage.ts
@@ -79,6 +79,8 @@ const homePage = {
               title: "Image",
               type: "image",
               options: { hotspot: true },
+              validation: (Rule: any) =>
+                Rule.required().error("Image is required"),
             },
             {
               name: "altText",

--- a/sanity/schemas/projectInfo.ts
+++ b/sanity/schemas/projectInfo.ts
@@ -43,6 +43,13 @@ const projectInfo = {
               validation: (Rule) => Rule.required(),
             }),
             defineField({
+              name: "subheading",
+              title: "Subheading",
+              type: "string",
+
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
               name: "bulletPoints",
               title: "Bullet Points",
               type: "array",

--- a/types/ProjectInfoPage.ts
+++ b/types/ProjectInfoPage.ts
@@ -10,6 +10,7 @@ export interface Card {
     };
   };
   alt: string;
+  subheading: string;
   bulletPoints: string[];
   detailedDescription: PortableTextBlock[];
 }


### PR DESCRIPTION
Make the image field mandatory in the home page schema, add a subheading field, and reorder the navigation bar for improved accessibility.