### PR TITLE
Add timeline support to section schema and styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,7 @@ export default async function Home() {
             key={index}
             title={section.title}
             imageIsOnRight={section.imageIsOnRight}
+            isTimeline={section.isTimeline}
             imageSrc={section.image.asset.url}
             altText={section.altText}
           >

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -24,15 +24,15 @@ const Section = ({
         <div className="w-full md:w-1/2 text-center md:text-left p-4">
           <h2 className="text-3xl font-semibold text-hdotTeal mb-4">{title}</h2>
           <hr className="border-t-2 border-hdotTeal my-4 w-full md:w-1/2" />
-          <div className="text-hdotHoverTeal text-lg">{children}</div>
         </div>
         <Image
           src={imageSrc}
           alt={altText}
           width={1000} // Adjust width as needed
-          height={300} // Adjust height as needed
+          height={400} // Adjust height as needed
           className=""
         />
+        <div className="text-hdotHoverTeal text-lg">{children}</div>
       </div>
     );
   } else {

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 interface SectionProps {
   title: string;
   imageIsOnRight: boolean;
+  isTimeline?: boolean;
   children?: ReactNode;
   imageSrc: string;
   altText: string;
@@ -13,36 +14,58 @@ const Section = ({
   title,
   children,
   imageIsOnRight,
+  isTimeline,
   imageSrc,
   altText,
 }: SectionProps) => {
-  return (
-    <section className={`my-8 p-8 `}>
-      <div
-        className={`flex flex-col md:flex-row items-center ${
-          imageIsOnRight ? "md:flex-row" : "md:flex-row-reverse"
-        }`}
-      >
-        {/* Content Section */}
+  if (isTimeline === true) {
+    return (
+      <div className="w-full flex flex-col justify-center items-center py-12 bg-gray-100 shadow-lg">
         <div className="w-full md:w-1/2 text-center md:text-left p-4">
           <h2 className="text-3xl font-semibold text-hdotTeal mb-4">{title}</h2>
           <hr className="border-t-2 border-hdotTeal my-4 w-full md:w-1/2" />
           <div className="text-hdotHoverTeal text-lg">{children}</div>
         </div>
-
-        {/* Image Section */}
-        <div className="w-full md:w-1/2 p-4 flex justify-center">
-          <Image
-            src={imageSrc}
-            alt={altText}
-            width={500} // Adjust width as needed
-            height={300} // Adjust height as needed
-            className=""
-          />
-        </div>
+        <Image
+          src={imageSrc}
+          alt={altText}
+          width={1000} // Adjust width as needed
+          height={300} // Adjust height as needed
+          className=""
+        />
       </div>
-    </section>
-  );
+    );
+  } else {
+    return (
+      <section className={`my-8 p-8 `}>
+        <div
+          className={`flex flex-col md:flex-row items-center ${
+            imageIsOnRight ? "md:flex-row" : "md:flex-row-reverse"
+          }`}
+        >
+          {/* Content Section */}
+          <div className="w-full md:w-1/2 text-center md:text-left p-4">
+            <h2 className="text-3xl font-semibold text-hdotTeal mb-4">
+              {title}
+            </h2>
+            <hr className="border-t-2 border-hdotTeal my-4 w-full md:w-1/2" />
+            <div className="text-hdotHoverTeal text-lg">{children}</div>
+          </div>
+
+          {/* Image Section */}
+          <div className="w-full md:w-1/2 p-4 flex justify-center">
+            <Image
+              src={imageSrc}
+              alt={altText}
+              width={500} // Adjust width as needed
+              height={300} // Adjust height as needed
+              className=""
+            />
+          </div>
+        </div>
+      </section>
+    );
+  }
 };
 
 export default Section;

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -38,6 +38,7 @@ export async function getHomePage(): Promise<HomePage> {
           },
           altText,
           imageIsOnRight,
+          isTimeline,
           buttonText,
           buttonLink
         }

--- a/sanity/schemas/homePage.ts
+++ b/sanity/schemas/homePage.ts
@@ -98,6 +98,13 @@ const homePage = {
                 "If checked, the image will appear on the right side.",
             },
             {
+              name: "isTimeline",
+              title: "Is this a timeline?",
+              type: "boolean",
+              description:
+                "Check this true ONLY if this section is a timeline, very important.",
+            },
+            {
               name: "buttonText",
               title: "Button Text",
               type: "string",

--- a/types/HomePage.ts
+++ b/types/HomePage.ts
@@ -32,6 +32,7 @@ export type HomePageSection = {
   };
   altText: string;
   imageIsOnRight: boolean;
+  isTimeline?: boolean;
   buttonText?: string;
   buttonLink?: string;
 };


### PR DESCRIPTION
Introduce an `isTimeline` boolean to the section schema and adjust the layout for timeline sections on the homepage. This change enhances the visual presentation of timeline sections.