### PR TITLE
Add Get Involved page with event details and document links

### DIFF
--- a/app/document-library/page.tsx
+++ b/app/document-library/page.tsx
@@ -4,6 +4,7 @@ import { DocumentsPage } from "@/types/DocumentsPage";
 const DocumentLibrary = async () => {
   try {
     const documentsPage: DocumentsPage = await getDocumentsPage();
+    console.log(documentsPage.subSections[0].documentLibrary[0].title);
 
     return (
       <div className="container mx-auto px-4 py-8">

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -12,9 +12,9 @@ async function getInvolved() {
       </h1>
 
       <div className="max-w-3xl mx-auto container">
-        <h2 className="text-2xl font-bold uppercase tracking-wide">
-          {getInvolvedPage.upcomingEventsTitle}
-        </h2>
+        <div className="text-2xl text-hdotTeal font-bold uppercase tracking-wide">
+          {getInvolvedPage.upcomingEventsTitle || "Upcoming Events"}
+        </div>
         <hr className="border-t-2 border-hdotTeal w-1/2" />
         {getInvolvedPage.upcomingEventsList.map((upcomingEvent) => {
           return (
@@ -28,19 +28,27 @@ async function getInvolved() {
                   <PortableText value={upcomingEvent.description} />
                 </div>
 
-                <h3 className="mt-6 text-lg font-bold uppercase text-green-700 tracking-wide">
-                  Meeting Materials
+                <div>
+                  <a href={upcomingEvent.link} className="hover:text-hdotJade">
+                    {upcomingEvent.link}
+                  </a>
+                </div>
+
+                <h3 className="mt-6 text-lg font-bold uppercase text-hdotJade tracking-wide">
+                  {upcomingEvent.documentsSectionTitle}
                 </h3>
 
                 <div className="mt-3 flex items-center space-x-3">
                   <div>
                     <p className="text-gray-500 uppercase text-xs font-semibold">
-                      PDF
+                      PDF title
                     </p>
                     <a
                       href="#"
-                      className="text-gray-800 hover:text-green-700 font-medium"
-                    ></a>
+                      className="text-gray-800 hover:hover:text-hdotJade font-medium"
+                    >
+                      PDF icon - link
+                    </a>
                   </div>
                 </div>
               </div>
@@ -50,9 +58,9 @@ async function getInvolved() {
 
         {/* Past Events */}
         <div>
-          <h2 className="text-2xl font-bold uppercase tracking-wide">
-            {getInvolvedPage.pastEventsTitle}
-          </h2>
+          <div className="text-2xl text-hdotTeal font-bold uppercase tracking-wide">
+            {getInvolvedPage.pastEventsTitle || "Past Events"}
+          </div>
           <hr className="border-t-2 border-hdotTeal w-1/2" />
 
           {getInvolvedPage.pastEventsList.map((pastEvent) => {
@@ -67,19 +75,21 @@ async function getInvolved() {
                     <PortableText value={pastEvent.description} />
                   </div>
 
-                  <h3 className="mt-6 text-lg font-bold uppercase text-green-700 tracking-wide">
-                    Meeting Materials
+                  <h3 className="mt-6 text-lg font-bold uppercase text-hdotJade">
+                    {pastEvent.documentsSectionTitle}
                   </h3>
 
                   <div className="mt-3 flex items-center space-x-3">
                     <div>
                       <p className="text-gray-500 uppercase text-xs font-semibold">
-                        PDF
+                        PDF title
                       </p>
                       <a
                         href="#"
-                        className="text-gray-800 hover:text-green-700 font-medium"
-                      ></a>
+                        className="text-gray-800 hover:hover:text-hdotJade font-medium"
+                      >
+                        PDF icon - link
+                      </a>
                     </div>
                   </div>
                 </div>

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -18,7 +18,7 @@ async function getInvolved() {
         <hr className="border-t-2 border-hdotTeal w-1/2" />
         {getInvolvedPage.upcomingEventsList.map((upcomingEvent) => {
           return (
-            <section className="py-6 ">
+            <section className="py-6" key={upcomingEvent._key}>
               <div className="bg-gray-100 shadow-lg p-6">
                 <h2 className="text-xl font-bold uppercase tracking-wide">
                   {upcomingEvent.title} | {upcomingEvent.dateTime}
@@ -41,7 +41,7 @@ async function getInvolved() {
                 <div className="mt-3 flex items-center space-x-3">
                   {upcomingEvent.documentsList?.map((document) => {
                     return (
-                      <div>
+                      <div key={document.fileUrl}>
                         <p className="text-gray-500 uppercase text-xs font-semibold">
                           {document.title}
                         </p>
@@ -69,7 +69,7 @@ async function getInvolved() {
 
           {getInvolvedPage.pastEventsList.map((pastEvent) => {
             return (
-              <section className="py-6 ">
+              <section className="py-6" key={pastEvent._key}>
                 <div className="bg-gray-100 shadow-lg p-6">
                   <h2 className="text-xl font-bold uppercase tracking-wide">
                     {pastEvent.title} | {pastEvent.dateTime}
@@ -86,7 +86,7 @@ async function getInvolved() {
                   <div className="mt-3 flex items-center space-x-3">
                     {pastEvent.documentsList?.map((document) => {
                       return (
-                        <div>
+                        <div key={document.fileUrl}>
                           <p className="text-gray-500 uppercase text-xs font-semibold">
                             {document.title}
                           </p>

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -4,19 +4,90 @@ import { GetInvolvedPage } from "@/types/GetInvolved";
 
 async function getInvolved() {
   const getInvolvedPage: GetInvolvedPage = await getGetInvolvedPage();
-  console.log(getInvolvedPage.upcomingEventsList[0].title);
+
   return (
     <>
-      <div>{getInvolvedPage.pageTitle}</div>;
-      <div>{getInvolvedPage.pastEventsTitle}</div>
-      <div>{getInvolvedPage.pastEventsSubtitle}</div>
-      {getInvolvedPage.upcomingEventsList.map((upcomingEvent) => {
-        return (
-          <>
-            <div>Upcoming Event title = {upcomingEvent.title}</div>
-          </>
-        );
-      })}
+      <h1 className="text-4xl font-bold text-center text-hdotTeal py-8">
+        {getInvolvedPage.pageTitle}
+      </h1>
+
+      <div className="max-w-3xl mx-auto container">
+        <h2 className="text-2xl font-bold uppercase tracking-wide">
+          {getInvolvedPage.upcomingEventsTitle}
+        </h2>
+        <hr className="border-t-2 border-hdotTeal w-1/2" />
+        {getInvolvedPage.upcomingEventsList.map((upcomingEvent) => {
+          return (
+            <section className="py-6 ">
+              <div className="bg-gray-100 shadow-lg p-6">
+                <h2 className="text-xl font-bold uppercase tracking-wide">
+                  {upcomingEvent.title} | {upcomingEvent.dateTime}
+                </h2>
+
+                <div className="mt-2">
+                  <PortableText value={upcomingEvent.description} />
+                </div>
+
+                <h3 className="mt-6 text-lg font-bold uppercase text-green-700 tracking-wide">
+                  Meeting Materials
+                </h3>
+
+                <div className="mt-3 flex items-center space-x-3">
+                  <div>
+                    <p className="text-gray-500 uppercase text-xs font-semibold">
+                      PDF
+                    </p>
+                    <a
+                      href="#"
+                      className="text-gray-800 hover:text-green-700 font-medium"
+                    ></a>
+                  </div>
+                </div>
+              </div>
+            </section>
+          );
+        })}
+
+        {/* Past Events */}
+        <div>
+          <h2 className="text-2xl font-bold uppercase tracking-wide">
+            {getInvolvedPage.pastEventsTitle}
+          </h2>
+          <hr className="border-t-2 border-hdotTeal w-1/2" />
+
+          {getInvolvedPage.pastEventsList.map((pastEvent) => {
+            return (
+              <section className="py-6 ">
+                <div className="bg-gray-100 shadow-lg p-6">
+                  <h2 className="text-xl font-bold uppercase tracking-wide">
+                    {pastEvent.title} | {pastEvent.dateTime}
+                  </h2>
+
+                  <div className="mt-2">
+                    <PortableText value={pastEvent.description} />
+                  </div>
+
+                  <h3 className="mt-6 text-lg font-bold uppercase text-green-700 tracking-wide">
+                    Meeting Materials
+                  </h3>
+
+                  <div className="mt-3 flex items-center space-x-3">
+                    <div>
+                      <p className="text-gray-500 uppercase text-xs font-semibold">
+                        PDF
+                      </p>
+                      <a
+                        href="#"
+                        className="text-gray-800 hover:text-green-700 font-medium"
+                      ></a>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
     </>
   );
 }

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -39,17 +39,21 @@ async function getInvolved() {
                 </h3>
 
                 <div className="mt-3 flex items-center space-x-3">
-                  <div>
-                    <p className="text-gray-500 uppercase text-xs font-semibold">
-                      PDF title
-                    </p>
-                    <a
-                      href="#"
-                      className="text-gray-800 hover:hover:text-hdotJade font-medium"
-                    >
-                      PDF icon - link
-                    </a>
-                  </div>
+                  {upcomingEvent.documentsList?.map((document) => {
+                    return (
+                      <div>
+                        <p className="text-gray-500 uppercase text-xs font-semibold">
+                          {document.title}
+                        </p>
+                        <a
+                          href={document.fileUrl}
+                          className="text-gray-800 hover:hover:text-hdotJade font-medium"
+                        >
+                          PDF icon - link
+                        </a>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             </section>
@@ -80,17 +84,21 @@ async function getInvolved() {
                   </h3>
 
                   <div className="mt-3 flex items-center space-x-3">
-                    <div>
-                      <p className="text-gray-500 uppercase text-xs font-semibold">
-                        PDF title
-                      </p>
-                      <a
-                        href="#"
-                        className="text-gray-800 hover:hover:text-hdotJade font-medium"
-                      >
-                        PDF icon - link
-                      </a>
-                    </div>
+                    {pastEvent.documentsList?.map((document) => {
+                      return (
+                        <div>
+                          <p className="text-gray-500 uppercase text-xs font-semibold">
+                            {document.title}
+                          </p>
+                          <a
+                            href={document.fileUrl}
+                            className="text-gray-800 hover:hover:text-hdotJade font-medium"
+                          >
+                            PDF icon - link
+                          </a>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               </section>

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -1,5 +1,24 @@
-function getInvolved() {
-  return <>Get involved page</>;
+import { PortableText } from "@portabletext/react";
+import { getGetInvolvedPage } from "@/sanity/sanity-utils";
+import { GetInvolvedPage } from "@/types/GetInvolved";
+
+async function getInvolved() {
+  const getInvolvedPage: GetInvolvedPage = await getGetInvolvedPage();
+  console.log(getInvolvedPage.upcomingEventsList[0].title);
+  return (
+    <>
+      <div>{getInvolvedPage.pageTitle}</div>;
+      <div>{getInvolvedPage.pastEventsTitle}</div>
+      <div>{getInvolvedPage.pastEventsSubtitle}</div>
+      {getInvolvedPage.upcomingEventsList.map((upcomingEvent) => {
+        return (
+          <>
+            <div>Upcoming Event title = {upcomingEvent.title}</div>
+          </>
+        );
+      })}
+    </>
+  );
 }
 
 export default getInvolved;

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -22,13 +22,13 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
         upcomingEventsTitle,
         upcomingEventsSubtitle,
         upcomingEventsList[]{
-          upcomingTitle,
-         
-          upcomingDescription,
-          upcomingDateTime,
-          upcomingLink,
-          upcomingDocumentsSectionTitle,
-          upcomingDocumentsList[]{
+          title,
+          subtitle,
+          description,
+          dateTime,
+          link,
+          documentsSectionTitle,
+          documentsList[]{
             documentItem[]{
               title,
               "fileUrl": file.asset->url
@@ -38,12 +38,13 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
         pastEventsTitle,
         pastEventsSubtitle,
         pastEventsList[]{
-          pastTitle,
-          pastDescription,
-          pastDateTime,
-          pastLink,
-          pastDocumentsSectionTitle,
-          pastDocumentsList[]{
+          title,
+          subtitle,
+          description,
+          dateTime,
+          link,
+          documentsSectionTitle,
+          documentsList[]{
             documentItem[]{
               title,
               "fileUrl": file.asset->url

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -18,10 +18,12 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
   try {
     const getInvolvedPage = await client.fetch(
       groq`*[_type == "getInvolved"][0]{
+      
         pageTitle,
         upcomingEventsTitle,
         upcomingEventsSubtitle,
         upcomingEventsList[]{
+        _key,
           title,
           subtitle,
           description,
@@ -36,6 +38,7 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
         pastEventsTitle,
         pastEventsSubtitle,
         pastEventsList[]{
+        _key,
           title,
           subtitle,
           description,

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -29,10 +29,8 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
           link,
           documentsSectionTitle,
           documentsList[]{
-            documentItem[]{
-              title,
-              "fileUrl": file.asset->url
-            }
+            title,
+            "fileUrl": file.asset->url
           }
         },
         pastEventsTitle,
@@ -45,10 +43,8 @@ export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
           link,
           documentsSectionTitle,
           documentsList[]{
-            documentItem[]{
-              title,
-              "fileUrl": file.asset->url
-            }
+            title,
+            "fileUrl": file.asset->url
           }
         }
       }`

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -3,6 +3,7 @@ import { HomePage } from "@/types/HomePage";
 import { CommentsPage } from "@/types/CommentsPage";
 import { DocumentsPage } from "@/types/DocumentsPage";
 import { ProjectInfo } from "@/types/ProjectInfoPage";
+import { GetInvolvedPage } from "@/types/GetInvolved";
 import { FAQ } from "@/types/FAQPage";
 
 export const client = createClient({
@@ -12,6 +13,52 @@ export const client = createClient({
   token: process.env.SANITY_API_TOKEN,
   useCdn: false,
 });
+
+export async function getGetInvolvedPage(): Promise<GetInvolvedPage> {
+  try {
+    const getInvolvedPage = await client.fetch(
+      groq`*[_type == "getInvolved"][0]{
+        pageTitle,
+        upcomingEventsTitle,
+        upcomingEventsSubtitle,
+        upcomingEventsList[]{
+          upcomingTitle,
+         
+          upcomingDescription,
+          upcomingDateTime,
+          upcomingLink,
+          upcomingDocumentsSectionTitle,
+          upcomingDocumentsList[]{
+            documentItem[]{
+              title,
+              "fileUrl": file.asset->url
+            }
+          }
+        },
+        pastEventsTitle,
+        pastEventsSubtitle,
+        pastEventsList[]{
+          pastTitle,
+          pastDescription,
+          pastDateTime,
+          pastLink,
+          pastDocumentsSectionTitle,
+          pastDocumentsList[]{
+            documentItem[]{
+              title,
+              "fileUrl": file.asset->url
+            }
+          }
+        }
+      }`
+    );
+
+    return getInvolvedPage;
+  } catch (error) {
+    console.error("Failed to fetch getInvolvedPage:", error);
+    throw new Error("Failed to fetch getInvolvedPage");
+  }
+}
 
 export async function getHomePage(): Promise<HomePage> {
   try {

--- a/sanity/schemas/getInvolved.ts
+++ b/sanity/schemas/getInvolved.ts
@@ -35,11 +35,17 @@ const getInvolved = {
           title: "Upcoming Event",
           fields: [
             defineField({
-              name: "upcomingTitle",
+              name: "title",
               title: "Event Title",
               type: "string",
               validation: (Rule) =>
                 Rule.required().error("Event title is required"),
+            }),
+            defineField({
+              name: "subtitle",
+              title: "Event Subtitle",
+              type: "string",
+              description: "This field is optional",
             }),
             defineField({
               name: "upcomingDescription",
@@ -107,11 +113,11 @@ const getInvolved = {
       title: "Past Events Title",
       type: "string",
       validation: (Rule) =>
-        Rule.required().error("Upcoming Events Title is required"),
+        Rule.required().error("Past Events Title is required"),
     }),
     defineField({
       name: "pastEventsSubtitle",
-      title: "Past Events Subtitle",
+      title: "Event Subtitle",
       type: "string",
       description: "This field is optional",
     }),
@@ -126,71 +132,70 @@ const getInvolved = {
           title: "Past Event",
           fields: [
             defineField({
-              name: "pastTitle",
+              name: "title",
               title: "Event Title",
               type: "string",
               validation: (Rule) =>
                 Rule.required().error("Event title is required"),
             }),
             defineField({
-              name: "pastSubtitle",
+              name: "subtitle",
               title: "Event Subitle",
               type: "string",
               description: "This field is optional",
             }),
             defineField({
-              name: "pastDescription",
+              name: "description",
               title: "Event Description",
               type: "array",
               of: [{ type: "block" }],
             }),
             defineField({
-              name: "pastDateTime",
+              name: "dateTime",
               title: "Event Date and Time",
               type: "string",
             }),
             defineField({
-              name: "pastLink",
+              name: "link",
               title: "Event Link",
               type: "url",
             }),
             defineField({
-              name: "pastDocumentsSectionTitle",
+              name: "documentsSectionTitle",
               title: "Related Documents Title",
               type: "string",
               description: "For example, 'Agenda' or 'Minutes'",
             }),
-          ],
-        },
-
-        {
-          name: "pastDocumentsList",
-          title: "Past Event Documents",
-          type: "object",
-          fields: [
             {
-              name: "documentItem",
-              title: "Document item",
-              type: "array",
-              of: [
+              name: "documentsList",
+              title: "Past Event Documents",
+              type: "object",
+              fields: [
                 {
-                  type: "object",
                   name: "documentItem",
                   title: "Document item",
-                  fields: [
-                    defineField({
-                      name: "title",
-                      title: "Document Title",
-                      type: "string",
-                      validation: (Rule) =>
-                        Rule.required().error("Document title is required"),
-                    }),
+                  type: "array",
+                  of: [
                     {
-                      name: "file",
-                      title: "PDF File",
-                      type: "file",
-                      description: "Upload a PDF file",
-                      options: { accept: ".pdf" },
+                      type: "object",
+                      name: "documentItem",
+                      title: "Document item",
+                      fields: [
+                        defineField({
+                          name: "title",
+                          title: "Document Title",
+                          type: "string",
+                          validation: (Rule) =>
+                            Rule.required().error("Document title is required"),
+                        }),
+                        {
+                          name: "file",
+                          title: "PDF File",
+                          type: "file",
+                          description: "Upload a PDF file",
+                          options: { accept: ".pdf" },
+                        },
+                      ],
                     },
                   ],
                 },

--- a/sanity/schemas/getInvolved.ts
+++ b/sanity/schemas/getInvolved.ts
@@ -103,11 +103,17 @@ const getInvolved = {
       ],
     },
     defineField({
-      name: "pastEvents",
+      name: "pastEventsTitle",
       title: "Past Events Title",
       type: "string",
       validation: (Rule) =>
         Rule.required().error("Upcoming Events Title is required"),
+    }),
+    defineField({
+      name: "pastEventsSubtitle",
+      title: "Past Events Subtitle",
+      type: "string",
+      description: "This field is optional",
     }),
     {
       name: "pastEventsList",

--- a/sanity/schemas/getInvolved.ts
+++ b/sanity/schemas/getInvolved.ts
@@ -1,0 +1,184 @@
+import { defineField } from "sanity";
+
+const getInvolved = {
+  name: "getInvolved",
+  title: "Get Involved",
+  type: "document",
+  fields: [
+    defineField({
+      name: "pageTitle",
+      title: "Page Title",
+      type: "string",
+      validation: (Rule) => Rule.required().error("Page title is required"),
+    }),
+    defineField({
+      name: "upcomingEvents",
+      title: "Upcoming Events Title",
+      type: "string",
+      validation: (Rule) =>
+        Rule.required().error("Upcoming Events Title is required"),
+    }),
+    {
+      name: "upcomingEventsList",
+      title: "Upcoming Events List",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          name: "pastEvent",
+          title: "Past Event",
+          fields: [
+            defineField({
+              name: "upcomingTitle",
+              title: "Event Title",
+              type: "string",
+              validation: (Rule) =>
+                Rule.required().error("Event title is required"),
+            }),
+            defineField({
+              name: "upcomingSubtitle",
+              title: "Event Subitle",
+              type: "string",
+              description: "This field is optional",
+            }),
+            defineField({
+              name: "upcomingDescription",
+              title: "Event Description",
+              type: "array",
+              of: [{ type: "block" }],
+            }),
+            defineField({
+              name: "upcomingDateTime",
+              title: "Event Date and Time",
+              type: "string",
+            }),
+            defineField({
+              name: "upcomingLink",
+              title: "Event Link",
+              type: "url",
+            }),
+            defineField({
+              name: "upcomingDocumentsSectionTitle",
+              title: "Related Documents Title",
+              type: "string",
+            }),
+            {
+              name: "upcomingDocumentsList",
+              title: "Upcoming Event Documents",
+              type: "object",
+              fields: [
+                {
+                  type: "object",
+                  name: "documentItem",
+                  title: "Document item",
+                  fields: [
+                    defineField({
+                      name: "title",
+                      title: "Document Title",
+                      type: "string",
+                      validation: (Rule) =>
+                        Rule.required().error("Document title is required"),
+                    }),
+                    {
+                      name: "file",
+                      title: "PDF File",
+                      type: "file",
+                      description: "Upload a PDF file",
+                      options: { accept: ".pdf" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    defineField({
+      name: "pastEvents",
+      title: "Past Events Title",
+      type: "string",
+      validation: (Rule) =>
+        Rule.required().error("Upcoming Events Title is required"),
+    }),
+    {
+      name: "pastEventsList",
+      title: "Past Events List",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          name: "pastEvent",
+          title: "Past Event",
+          fields: [
+            defineField({
+              name: "pastTitle",
+              title: "Event Title",
+              type: "string",
+              validation: (Rule) =>
+                Rule.required().error("Event title is required"),
+            }),
+            defineField({
+              name: "pastSubtitle",
+              title: "Event Subitle",
+              type: "string",
+              description: "This field is optional",
+            }),
+            defineField({
+              name: "pastDescription",
+              title: "Event Description",
+              type: "array",
+              of: [{ type: "block" }],
+            }),
+            defineField({
+              name: "pastDateTime",
+              title: "Event Date and Time",
+              type: "string",
+            }),
+            defineField({
+              name: "pastLink",
+              title: "Event Link",
+              type: "url",
+            }),
+            defineField({
+              name: "pastDocumentsSectionTitle",
+              title: "Related Documents Title",
+              type: "string",
+            }),
+          ],
+        },
+
+        {
+          name: "pastDocumentsList",
+          title: "Past Event Documents",
+          type: "object",
+          fields: [
+            {
+              type: "object",
+              name: "documentItem",
+              title: "Document item",
+              fields: [
+                defineField({
+                  name: "title",
+                  title: "Document Title",
+                  type: "string",
+                  validation: (Rule) =>
+                    Rule.required().error("Document title is required"),
+                }),
+                {
+                  name: "file",
+                  title: "PDF File",
+                  type: "file",
+                  description: "Upload a PDF file",
+                  options: { accept: ".pdf" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default getInvolved;

--- a/sanity/schemas/getInvolved.ts
+++ b/sanity/schemas/getInvolved.ts
@@ -48,57 +48,51 @@ const getInvolved = {
               description: "This field is optional",
             }),
             defineField({
-              name: "upcomingDescription",
+              name: "description",
               title: "Event Description",
               type: "array",
               of: [{ type: "block" }],
             }),
             defineField({
-              name: "upcomingDateTime",
+              name: "dateTime",
               title: "Event Date and Time",
               type: "string",
             }),
             defineField({
-              name: "upcomingLink",
+              name: "link",
               title: "Event Link",
               type: "url",
             }),
             defineField({
-              name: "upcomingDocumentsSectionTitle",
+              name: "documentsSectionTitle",
               title: "Related Documents Title",
               type: "string",
               description: "For example, 'Agenda' or 'Minutes'",
             }),
+
             {
-              name: "upcomingDocumentsList",
+              name: "documentsList",
               title: "Upcoming Event Documents",
-              type: "object",
-              fields: [
+              type: "array",
+              of: [
                 {
+                  type: "object",
                   name: "documentItem",
                   title: "Document item",
-                  type: "array",
-                  of: [
+                  fields: [
+                    defineField({
+                      name: "title",
+                      title: "Document Title",
+                      type: "string",
+                      validation: (Rule) =>
+                        Rule.required().error("Document title is required"),
+                    }),
                     {
-                      type: "object",
-                      name: "documentItem",
-                      title: "Document item",
-                      fields: [
-                        defineField({
-                          name: "title",
-                          title: "Document Title",
-                          type: "string",
-                          validation: (Rule) =>
-                            Rule.required().error("Document title is required"),
-                        }),
-                        {
-                          name: "file",
-                          title: "PDF File",
-                          type: "file",
-                          description: "Upload a PDF file",
-                          options: { accept: ".pdf" },
-                        },
-                      ],
+                      name: "file",
+                      title: "PDF File",
+                      type: "file",
+                      description: "Upload a PDF file",
+                      options: { accept: ".pdf" },
                     },
                   ],
                 },
@@ -166,36 +160,30 @@ const getInvolved = {
               type: "string",
               description: "For example, 'Agenda' or 'Minutes'",
             }),
+
             {
               name: "documentsList",
               title: "Past Event Documents",
-              type: "object",
-              fields: [
+              type: "array",
+              of: [
                 {
+                  type: "object",
                   name: "documentItem",
                   title: "Document item",
-                  type: "array",
-                  of: [
+                  fields: [
+                    defineField({
+                      name: "title",
+                      title: "Document Title",
+                      type: "string",
+                      validation: (Rule) =>
+                        Rule.required().error("Document title is required"),
+                    }),
                     {
-                      type: "object",
-                      name: "documentItem",
-                      title: "Document item",
-                      fields: [
-                        defineField({
-                          name: "title",
-                          title: "Document Title",
-                          type: "string",
-                          validation: (Rule) =>
-                            Rule.required().error("Document title is required"),
-                        }),
-                        {
-                          name: "file",
-                          title: "PDF File",
-                          type: "file",
-                          description: "Upload a PDF file",
-                          options: { accept: ".pdf" },
-                        },
-                      ],
+                      name: "file",
+                      title: "PDF File",
+                      type: "file",
+                      description: "Upload a PDF file",
+                      options: { accept: ".pdf" },
                     },
                   ],
                 },

--- a/sanity/schemas/getInvolved.ts
+++ b/sanity/schemas/getInvolved.ts
@@ -12,11 +12,17 @@ const getInvolved = {
       validation: (Rule) => Rule.required().error("Page title is required"),
     }),
     defineField({
-      name: "upcomingEvents",
+      name: "upcomingEventsTitle",
       title: "Upcoming Events Title",
       type: "string",
       validation: (Rule) =>
         Rule.required().error("Upcoming Events Title is required"),
+    }),
+    defineField({
+      name: "upcomingEventsSubtitle",
+      title: "Upcoming Events Subtitle",
+      type: "string",
+      description: "This field is optional",
     }),
     {
       name: "upcomingEventsList",
@@ -25,8 +31,8 @@ const getInvolved = {
       of: [
         {
           type: "object",
-          name: "pastEvent",
-          title: "Past Event",
+          name: "upcomingEvent",
+          title: "Upcoming Event",
           fields: [
             defineField({
               name: "upcomingTitle",
@@ -34,12 +40,6 @@ const getInvolved = {
               type: "string",
               validation: (Rule) =>
                 Rule.required().error("Event title is required"),
-            }),
-            defineField({
-              name: "upcomingSubtitle",
-              title: "Event Subitle",
-              type: "string",
-              description: "This field is optional",
             }),
             defineField({
               name: "upcomingDescription",
@@ -61,6 +61,7 @@ const getInvolved = {
               name: "upcomingDocumentsSectionTitle",
               title: "Related Documents Title",
               type: "string",
+              description: "For example, 'Agenda' or 'Minutes'",
             }),
             {
               name: "upcomingDocumentsList",
@@ -68,23 +69,30 @@ const getInvolved = {
               type: "object",
               fields: [
                 {
-                  type: "object",
                   name: "documentItem",
                   title: "Document item",
-                  fields: [
-                    defineField({
-                      name: "title",
-                      title: "Document Title",
-                      type: "string",
-                      validation: (Rule) =>
-                        Rule.required().error("Document title is required"),
-                    }),
+                  type: "array",
+                  of: [
                     {
-                      name: "file",
-                      title: "PDF File",
-                      type: "file",
-                      description: "Upload a PDF file",
-                      options: { accept: ".pdf" },
+                      type: "object",
+                      name: "documentItem",
+                      title: "Document item",
+                      fields: [
+                        defineField({
+                          name: "title",
+                          title: "Document Title",
+                          type: "string",
+                          validation: (Rule) =>
+                            Rule.required().error("Document title is required"),
+                        }),
+                        {
+                          name: "file",
+                          title: "PDF File",
+                          type: "file",
+                          description: "Upload a PDF file",
+                          options: { accept: ".pdf" },
+                        },
+                      ],
                     },
                   ],
                 },
@@ -144,6 +152,7 @@ const getInvolved = {
               name: "pastDocumentsSectionTitle",
               title: "Related Documents Title",
               type: "string",
+              description: "For example, 'Agenda' or 'Minutes'",
             }),
           ],
         },
@@ -154,23 +163,30 @@ const getInvolved = {
           type: "object",
           fields: [
             {
-              type: "object",
               name: "documentItem",
               title: "Document item",
-              fields: [
-                defineField({
-                  name: "title",
-                  title: "Document Title",
-                  type: "string",
-                  validation: (Rule) =>
-                    Rule.required().error("Document title is required"),
-                }),
+              type: "array",
+              of: [
                 {
-                  name: "file",
-                  title: "PDF File",
-                  type: "file",
-                  description: "Upload a PDF file",
-                  options: { accept: ".pdf" },
+                  type: "object",
+                  name: "documentItem",
+                  title: "Document item",
+                  fields: [
+                    defineField({
+                      name: "title",
+                      title: "Document Title",
+                      type: "string",
+                      validation: (Rule) =>
+                        Rule.required().error("Document title is required"),
+                    }),
+                    {
+                      name: "file",
+                      title: "PDF File",
+                      type: "file",
+                      description: "Upload a PDF file",
+                      options: { accept: ".pdf" },
+                    },
+                  ],
                 },
               ],
             },

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,16 +1,18 @@
 import { SchemaTypeDefinition } from "sanity";
 import homePage from "./homePage";
 import commentsPage from "./commentsPage";
+import getInvolved from "./getInvolved";
 import documents from "./documents";
 import projectInfo from "./projectInfo";
 import faq from "./faq";
 
 const schemas: SchemaTypeDefinition[] = [
   homePage,
-  commentsPage,
-  documents,
   projectInfo,
+  getInvolved,
   faq,
+  documents,
+  commentsPage,
 ];
 
 export default schemas;

--- a/types/GetInvolved.ts
+++ b/types/GetInvolved.ts
@@ -4,10 +4,6 @@ export interface DocumentItem {
   fileUrl: string;
 }
 
-export interface DocumentsList {
-  documentItem: DocumentItem[];
-}
-
 export interface Event {
   title: string;
   subtitle?: string;
@@ -15,7 +11,7 @@ export interface Event {
   dateTime: string;
   link?: string;
   documentsSectionTitle?: string;
-  documentsList: DocumentsList[];
+  documentsList?: DocumentItem[]; // ✅ Just an array of `DocumentItem`
 }
 
 export interface GetInvolvedPage {

--- a/types/GetInvolved.ts
+++ b/types/GetInvolved.ts
@@ -1,0 +1,27 @@
+import { PortableTextBlock } from "next-sanity";
+export interface DocumentItem {
+  title: string;
+  fileUrl: string;
+}
+
+export interface Event {
+  title: string;
+  subtitle?: string;
+  description: PortableTextBlock[];
+  dateTime: string;
+  link?: string;
+  documentsSectionTitle?: string;
+  documentsList: {
+    documentItem?: DocumentItem[];
+  }[];
+}
+
+export interface GetInvolvedPage {
+  pageTitle: string;
+  upcomingEventsTitle: string;
+  upcomingEventsSubtitle?: string;
+  upcomingEventsList: Event[];
+  pastEventsTitle: string;
+  pastEventsSubtitle?: string;
+  pastEventsList: Event[];
+}

--- a/types/GetInvolved.ts
+++ b/types/GetInvolved.ts
@@ -4,6 +4,10 @@ export interface DocumentItem {
   fileUrl: string;
 }
 
+export interface DocumentsList {
+  documentItem: DocumentItem[];
+}
+
 export interface Event {
   title: string;
   subtitle?: string;
@@ -11,9 +15,7 @@ export interface Event {
   dateTime: string;
   link?: string;
   documentsSectionTitle?: string;
-  documentsList: {
-    documentItem?: DocumentItem[];
-  }[];
+  documentsList: DocumentsList[];
 }
 
 export interface GetInvolvedPage {

--- a/types/GetInvolved.ts
+++ b/types/GetInvolved.ts
@@ -5,6 +5,7 @@ export interface DocumentItem {
 }
 
 export interface Event {
+  _key: string;
   title: string;
   subtitle?: string;
   description: PortableTextBlock[];


### PR DESCRIPTION
Introduce the Get Involved page schema and implement fetching and rendering of upcoming and past events, including associated documents. Streamline the data structure for efficient querying and mapping.
Frontend mapping through schema for dynamic display