### PR TITLE
Add isIcon boolean for image sizing on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,7 @@ export default async function Home() {
             title={section.title}
             imageIsOnRight={section.imageIsOnRight}
             isTimeline={section.isTimeline}
+            isIcon={section.isIcon}
             imageSrc={section.image.asset.url}
             altText={section.altText}
           >

--- a/components/Section/Section.tsx
+++ b/components/Section/Section.tsx
@@ -5,6 +5,7 @@ interface SectionProps {
   title: string;
   imageIsOnRight: boolean;
   isTimeline?: boolean;
+  isIcon?: boolean;
   children?: ReactNode;
   imageSrc: string;
   altText: string;
@@ -15,6 +16,7 @@ const Section = ({
   children,
   imageIsOnRight,
   isTimeline,
+  isIcon,
   imageSrc,
   altText,
 }: SectionProps) => {
@@ -38,7 +40,7 @@ const Section = ({
     );
   } else {
     return (
-      <section className={`my-8 p-8 `}>
+      <section className="my-8 p-8">
         <div
           className={`flex flex-col md:flex-row items-center ${
             imageIsOnRight ? "md:flex-row" : "md:flex-row-reverse"
@@ -54,13 +56,12 @@ const Section = ({
           </div>
 
           {/* Image Section */}
-          <div className="w-full md:w-1/2 p-4 flex justify-center ">
+          <div className="w-full md:w-1/2 p-4 flex justify-center">
             <Image
               src={imageSrc}
               alt={altText}
-              width={400} // Adjust width as needed
-              height={600}
-              objectFit="cover" // Adjust height as needed
+              width={isIcon ? 250 : 500} // Smaller if isIcon is true
+              height={isIcon ? 250 : 400}
               className=""
             />
           </div>

--- a/sanity/sanity-utils.ts
+++ b/sanity/sanity-utils.ts
@@ -86,6 +86,7 @@ export async function getHomePage(): Promise<HomePage> {
           altText,
           imageIsOnRight,
           isTimeline,
+          isIcon,
           buttonText,
           buttonLink
         }

--- a/sanity/schemas/homePage.ts
+++ b/sanity/schemas/homePage.ts
@@ -1,3 +1,4 @@
+import { defineField } from "sanity";
 const homePage = {
   name: "homePage",
   title: "Home Page",
@@ -97,6 +98,14 @@ const homePage = {
               description:
                 "If checked, the image will appear on the right side.",
             },
+            {
+              name: "isIcon",
+              title: "Is this an icon?",
+              type: "boolean",
+              description:
+                "If checked, the sizing of the image will be adjusted to fit the icon size.",
+            },
+
             {
               name: "isTimeline",
               title: "Is this a timeline?",

--- a/types/HomePage.ts
+++ b/types/HomePage.ts
@@ -33,6 +33,7 @@ export type HomePageSection = {
   altText: string;
   imageIsOnRight: boolean;
   isTimeline?: boolean;
+  isIcon?: boolean;
   buttonText?: string;
   buttonLink?: string;
 };


### PR DESCRIPTION
Introduce an `isIcon` boolean to adjust image dimensions based on whether the image is an icon, enhancing the homepage's visual flexibility.