### PR TITLE
Reduce icon size in project info card

### DIFF
--- a/components/ProjectInfoCard/ProjectInfoCard.tsx
+++ b/components/ProjectInfoCard/ProjectInfoCard.tsx
@@ -15,10 +15,10 @@ function ProjectInfoCard(props: Card) {
         <Image
           src={props.image.asset.url}
           alt={props.alt}
-          width={200}
-          height={200}
+          width={150}
+          height={150}
           objectFit="cover"
-          className="w-90 h-auto rounded-lg shadow-sm"
+          className="w-90 h-auto"
         />
       </div>
       <div className="p-2">


### PR DESCRIPTION
Decrease the icon size in the Project Info Card for improved layout and aesthetics.