### PR TITLE
Add alt text field for comments main image

### DIFF
--- a/app/submit-comments/page.tsx
+++ b/app/submit-comments/page.tsx
@@ -31,7 +31,7 @@ async function SubmitComments() {
           <div className="flex justify-center items-center">
             <Image
               src={commentsPage.mainImage.asset.url}
-              alt={commentsPage.mainImage.alt || "Default alt text"}
+              alt={commentsPage.mainImage.alt|| "Default alt text"}
               priority
               width={400}
               height={200}

--- a/sanity/schemas/commentsPage.ts
+++ b/sanity/schemas/commentsPage.ts
@@ -27,6 +27,14 @@ export default {
       },
     },
     {
+      name: "alt",
+      title: "Alt Text",
+      type: "string",
+      description: "Describe the image for accessibility.",
+      validation: (Rule: any) =>
+        Rule.required().error("Alt text is required"),
+    },
+    {
       name: "formFields",
       title: "Form Fields",
       type: "object",

--- a/types/CommentsPage.ts
+++ b/types/CommentsPage.ts
@@ -28,7 +28,7 @@ export type CommentsPage = {
       _id: string;
       url: string;
     };
-    alt?: string; // Optional in case it's missing
+    alt: string; // Optional in case it's missing
   };
   formFields: {
     name: string;


### PR DESCRIPTION
Introduce an alt text field for the main image in comments to enhance accessibility. This change ensures that alt text is required for the image, improving compliance with accessibility standards.